### PR TITLE
Task categories functionality

### DIFF
--- a/beanie_batteries_queue/queue.py
+++ b/beanie_batteries_queue/queue.py
@@ -1,13 +1,29 @@
 import asyncio
 from datetime import datetime
 from enum import Enum
-from typing import Type, Optional, Dict, ClassVar
+from typing import Type, Optional, Dict, ClassVar, Union
 
 from beanie import Document
 from beanie.odm.enums import SortDirection
 from beanie.odm.queries.update import UpdateResponse
+
 from pydantic import Field
 from pymongo import DESCENDING, ASCENDING
+
+
+def make_find_category(category: Optional[Union[str, list, set]]):
+    if not category:
+        return category
+    
+    normalized_category = category
+
+    if isinstance(category, str):
+        normalized_category = [category]
+
+    if isinstance(category, set):
+        normalized_category = [*category, ]
+
+    return {"$in": normalized_category}
 
 
 class State(str, Enum):
@@ -30,18 +46,19 @@ class DependencyType(str, Enum):
 
 
 class Queue:
-    def __init__(self, task_model: Type["Task"], sleep_time: int = 1):
+    def __init__(self, task_model: Type["Task"], sleep_time: int = 1, category: Optional[Union[str, list]] = None):
         self.task_model = task_model
         self.sleep_time = sleep_time
+        self.category = category
 
     def __aiter__(self):
         return self
 
     async def __anext__(self):
-        task = await self.task_model.pop()
+        task = await self.task_model.pop(category=self.category)
         while task is None:
             await asyncio.sleep(self.sleep_time)
-            task = await self.task_model.pop()
+            task = await self.task_model.pop(category=self.category)
         return task
 
 
@@ -50,6 +67,7 @@ class Task(Document):
     priority: Priority = Priority.MEDIUM
     created_at: datetime = Field(default_factory=datetime.utcnow)
     _dependency_fields: ClassVar[Optional[Dict[str, DependencyType]]] = None
+    category: Optional[str] = Field(description="Category of Task")
 
     class Settings:
         indexes = [
@@ -57,6 +75,7 @@ class Task(Document):
                 ("state", ASCENDING),
                 ("priority", DESCENDING),
                 ("created_at", ASCENDING),
+                ("category", ASCENDING),
             ],
             # expire after 1 day
             [("created_at", ASCENDING), ("expireAfterSeconds", 86400)],
@@ -76,13 +95,13 @@ class Task(Document):
         await self.save()
 
     @classmethod
-    async def pop(cls) -> Optional["Task"]:
+    async def pop(cls, category: Optional[Union[str, list, set]] = None) -> Optional["Task"]:
         """
         Get the first task from the queue
         :return:
         """
         task = None
-        find_query = cls.make_find_query()
+        find_query = cls.make_find_query(category=category)
         found_task = (
             await cls.find(find_query, fetch_links=True)
             .sort(
@@ -95,19 +114,22 @@ class Task(Document):
         )
         if found_task is not None:
             task = await cls.find_one(
-                {"_id": found_task.id, "state": State.CREATED}
+                {"_id": found_task.id, "state": State.CREATED, "category": make_find_category(category)}
             ).update(
                 {"$set": {"state": State.RUNNING}},
                 response_type=UpdateResponse.NEW_DOCUMENT,
             )
             # check if this task was not taken by another worker
             if task is None:
-                task = await cls.pop()
+                task = await cls.pop(category=category)
         return task
 
     @classmethod
-    def make_find_query(cls):
-        queries = [{"state": State.CREATED}]
+    def make_find_query(cls, category: Optional[Union[str, list, set]] = None):
+        queries = [
+            {"state": State.CREATED},
+            {"category": make_find_category(category)},
+        ]
         if cls._dependency_fields is not None:
             for (
                 dependency_field,
@@ -151,21 +173,22 @@ class Task(Document):
             }
 
     @classmethod
-    async def is_empty(cls) -> bool:
+    async def is_empty(cls, category: Optional[Union[str, list, set]] = None) -> bool:
         """
         Check if there are no tasks in the queue
         :return:
         """
-        return await cls.find_one({"state": State.CREATED}) is None
+        return await cls.find_one({"state": State.CREATED, "category": make_find_category(category)}) is None
 
     @classmethod
-    def queue(cls, sleep_time: int = 1):
+    def queue(cls, sleep_time: int = 1, category: Optional[Union[str, list, set]] = None):
         """
         Get queue iterator
         :param sleep_time:
+        :param category:
         :return:
         """
-        return Queue(cls, sleep_time=sleep_time)
+        return Queue(cls, sleep_time=sleep_time, category=category)
 
     async def finish(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie_batteries_queue"
-version = "0.3.0"
+version = "0.4.0"
 description = "Simple queue system for Beanie"
 readme = "README.md"
 requires-python = ">=3.7,<4.0"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,7 @@
 import pytest
 
+import asyncio
+
 from beanie_batteries_queue import State, Priority
 from tests.tasks import (
     SimpleTask,
@@ -24,6 +26,29 @@ class TestGeneralCases:
 
         task = await SimpleTask.find_one({"s": "test"})
         assert task.state == State.FINISHED
+
+    async def test_simple_pipeline_anext(self):
+        async def create_task():
+            simple_task = SimpleTask(s="test")
+            await simple_task.push()
+
+        async def create_slow_task():
+            asyncio.sleep(2)
+            await create_task()
+
+        await create_task()
+
+        cntr: int = 0
+        async for task in SimpleTask.queue():
+            cntr += 1
+            await task.finish()
+            slow_task = asyncio.create_task(create_slow_task())
+
+            if cntr == 2:
+                await task.finish()
+                break
+
+        await slow_task
 
     async def test_simple_pipeline_failed(self):
         task = SimpleTask(s="test")
@@ -242,3 +267,89 @@ class TestGeneralCases:
         assert found_task is not None
         assert found_task.s == "test2"
         assert found_task.state == State.RUNNING
+
+    async def test_simple_category_pipeline(self):
+        task_type2 = SimpleTask(s="test2", category="type2")
+        await task_type2.push()
+
+        task_type1 = SimpleTask(s="test1", category="type1")
+        await task_type1.push()
+
+        assert len(await SimpleTask.find({}).to_list()) == 2
+
+        async for task in SimpleTask.queue(category="type1"):
+            assert task.s == "test1"
+            await task.finish()
+            assert await SimpleTask.is_empty(category="type1")
+            assert not await SimpleTask.is_empty(category="type2")
+            break
+
+        task_type1 = await SimpleTask.find_one({"s": "test1"})
+        assert task_type1.state == State.FINISHED
+
+        task_type2 = await SimpleTask.find_one({"s": "test2"})
+        assert task_type2.state == State.CREATED
+
+    async def test_simple_category_pipeline_failed(self):
+        task_type1 = SimpleTask(s="test1", category="type1")
+        await task_type1.push()
+
+        task_type2 = SimpleTask(s="test2", category="type2")
+        await task_type2.push()
+
+        assert len(await SimpleTask.find({}).to_list()) == 2
+
+        async for task in SimpleTask.queue(category="type1"):
+            assert task.s == "test1"
+            await task.fail()
+            assert await SimpleTask.is_empty(category="type1")
+            assert not await SimpleTask.is_empty(category="type2")
+            break
+
+        task_type1 = await SimpleTask.find_one({"s": "test1"})
+        assert task_type1.state == State.FAILED
+
+        task_type2 = await SimpleTask.find_one({"s": "test2"})
+        assert task_type2.state == State.CREATED
+
+    async def test_category_normalization(self):
+        task_type_empty = SimpleTask(s="test_empty")
+        await task_type_empty.push()
+        assert await SimpleTask.pop()
+        await task_type_empty.finish()
+
+        task_type_string = SimpleTask(s="test_string", category="string")
+        await task_type_string.push()
+        assert await SimpleTask.pop(category="string")
+        await task_type_string.finish()
+
+        task_type_set = SimpleTask(s="test_set", category="set")
+        await task_type_set.push()
+        assert await SimpleTask.pop(category={"set"})
+        await task_type_set.finish()
+
+        task_type_list = SimpleTask(s="test_list", category="list")
+        await task_type_list.push()
+        assert await SimpleTask.pop(category=["list"])
+        await task_type_list.finish()
+
+    async def test_multi_category_queue(self):
+        task_empty = SimpleTask(s="test_empty")
+        await task_empty.push()
+
+        task_cat_1 = SimpleTask(s="test_cat_1", category="cat_1")
+        await task_cat_1.push()
+
+        task_cat_2 = SimpleTask(s="test_cat_2", category="cat_2")
+        await task_cat_2.push()
+
+        assert len(await SimpleTask.find({}).to_list()) == 3
+
+        cntr = 0
+        async for task in SimpleTask.queue(category=["cat_1", "cat_2"]):
+            assert task.s != "test_empty"
+            await task.finish()
+            cntr += 1
+            assert await SimpleTask.is_empty(category=task.category)
+            if cntr == 2:
+                break


### PR DESCRIPTION
Added support for optional `categories` of `Task`, to allow for focused `task` worker designs, such that load can be distributed across multiple workers based upon the type of `task` they should be processing.

```python
# Producer(s)
from beanie_batteries_queue import Task

class SimpleTask(Task):
    s: str


task_empty = SimpleTask(s="test")
await task_empty.push()

task_cat_1 = SimpleTask(s="test_cat_1", category="cat_1")
await task_cat_1.push()

task_cat_2 = SimpleTask(s="test_cat_2", category="cat_2")
await task_cat_2.push()
```

You can then have your worker(s) focus on chosen categories:

```python
# Consumer
async for task in SimpleTask.queue(): # no category
    assert task.s == "test"
    # Do some work
    await task.finish()
    break

# -or-
async for task in SimpleTask.queue(category="cat_1"): # one category
    assert task.s == "test_cat1"
    # Do some work
    await task.finish()
    break

# -or-
async for task in SimpleTask.queue(category=["cat_1", "cat_2"]): # multiple categories
    assert task.s in ["test_cat1", "test_cat2"]
    # Do some work
    await task.finish()
    break
```

Unit tests included, supports all existing functionality such as `pop`, and is backwards compatible with previous versions.